### PR TITLE
Create functionality to run valgrind

### DIFF
--- a/perf_tracker/perf_controller.py
+++ b/perf_tracker/perf_controller.py
@@ -31,6 +31,9 @@ class PerfController():
 
     def run_tests(self):
         for prog in self.progs:
+            prog.run_commands()
+            if self.valgrind:
+                prog.run_valgrind()
             prog.run_all_tests(self.iterations)
         self.comparison_graph()
 

--- a/perf_tracker/prog.py
+++ b/perf_tracker/prog.py
@@ -142,8 +142,6 @@ class Prog():
 
         std_err_out = cache_process.stderr.decode("utf-8")
 
-        pid = std_err_out.split("==")[1]
-
         with open(val_out_dir / "callgrind.txt", "w+") as leak_file:
 
             leak_file.write(f"Return Code: {cache_process.returncode}")
@@ -158,6 +156,7 @@ class Prog():
             print(f"Failed to run valgrind")
             return
 
+        pid = std_err_out.split("==")[1]
         Path(f"callgrind.out.{pid}").rename(
             str(val_out_dir / f"callgrind.out.{pid}"))
 


### PR DESCRIPTION
This implements the valgrind flag. If the flag is present, the program will run callgrind with cache tracking and annotate the output files. It is also protected against computers which do not have valgrind installed. 